### PR TITLE
Fix install.sh script: prevent uv init error on existing pyproject.toml

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -24,7 +24,6 @@ git clone "$REPO_URL"
 cd "$REPO_DIR"
 
 echo "Creating virtual environment (.venv) and installing dependencies..."
-uv init
 uv venv
 source .venv/bin/activate
 uv add pyinstaller


### PR DESCRIPTION
This pull request removes the uv init command from install.sh to prevent an error caused by an existing pyproject.toml file in the cloned repository.
Since the project is already initialized, running uv init is unnecessary and leads to a failure during installation.