### PR TITLE
Fix typo in echo statement in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -36,4 +36,4 @@ cd ..
 rm -rf "$REPO_DIR"
 
 
-echo "✅ Build complete! The app is in the 'dist' folder."s
+echo "✅ Build complete! The app is in the 'dist' folder."


### PR DESCRIPTION
This update removes a minor typo in the install script where an extra "s" was appended to an echo message. Though it did not cause runtime issues, it has now been corrected for clarity.

Fixes #5